### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ In order to run script all you have to do is run `chmod +x init && chmod +x pre-
 
 ### Start docker containers and install dependencies
 
+NOTE: To enter laravel container execute
+`docker exec -it laravel /bin/sh`
+
 - Run docker containers in detached mode
   `docker-compose up -d`
 


### PR DESCRIPTION
Now, you know how to **execute artisan/composer commands** without typing `docker exec -it laravel ...` every single time.